### PR TITLE
feat: auto-close composer pane

### DIFF
--- a/app/desktop/components/composer/ComposerPane.tsx
+++ b/app/desktop/components/composer/ComposerPane.tsx
@@ -527,6 +527,9 @@ const ComposerPane = () => {
 		// We're done here, let's reset this entire state.
 		{
 			composer._reset();
+			if (preferences.ui.autoCloseComposer) {
+				composer._hide();
+			}
 		}
 
 		// Anything afterwards is not necessary for the composer functionality,

--- a/app/desktop/components/settings/settings-views/InterfaceView.tsx
+++ b/app/desktop/components/settings/settings-views/InterfaceView.tsx
@@ -73,6 +73,11 @@ const AppearanceView = () => {
 							value={ui.threadedReplies}
 							onChange={(next) => (ui.threadedReplies = next)}
 						/>
+						<CheckItem
+							title="Close composer after posting"
+							value={ui.autoCloseComposer}
+							onChange={(next) => (ui.autoCloseComposer = next)}
+						/>
 					</div>
 				</div>
 

--- a/app/desktop/globals/settings.ts
+++ b/app/desktop/globals/settings.ts
@@ -29,6 +29,8 @@ export interface PreferencesSchema {
 		profileMediaGrid: boolean;
 		/** Show thread replies in a threaded view */
 		threadedReplies: boolean;
+		/** Close compser after posting */
+		autoCloseComposer: boolean;
 		/** Who can reply to your posts */
 		defaultReplyGate: 'e' | 'm' | 'f';
 	};
@@ -58,6 +60,7 @@ export const preferences = createReactiveLocalStorage<PreferencesSchema>(PREF_KE
 				defaultPaneSize: PaneSize.MEDIUM,
 				profileMediaGrid: true,
 				threadedReplies: false,
+				autoCloseComposer: false,
 				defaultReplyGate: 'e',
 			},
 			a11y: {

--- a/app/desktop/lib/settings/backup.ts
+++ b/app/desktop/lib/settings/backup.ts
@@ -261,6 +261,7 @@ export const backupSchema = v.object({
 		defaultPaneSize: v.union(v.literal('sm'), v.literal('md'), v.literal('lg')),
 		profileMediaGrid: v.boolean(),
 		threadedReplies: v.boolean(),
+		autoCloseComposer: v.boolean(),
 		defaultReplyGate: v.union(v.literal('everyone'), v.literal('mentioned'), v.literal('followed')),
 	}),
 	a11y: v.object({
@@ -866,6 +867,7 @@ export const fromBackup = (data: Backup, isOnboarding: boolean): PreferencesSche
 			profileMediaGrid: data.ui.profileMediaGrid,
 			theme: data.ui.theme,
 			threadedReplies: data.ui.threadedReplies,
+			autoCloseComposer: data.ui.autoCloseComposer,
 		},
 		a11y: {
 			warnNoMediaAlt: data.a11y.warnNoMediaAlt,
@@ -901,6 +903,7 @@ export const toBackup = (data: PreferencesSchema): Backup => {
 			profileMediaGrid: data.ui.profileMediaGrid,
 			theme: data.ui.theme,
 			threadedReplies: data.ui.threadedReplies,
+			autoCloseComposer: data.ui.autoCloseComposer,
 		},
 		a11y: {
 			warnNoMediaAlt: data.a11y.warnNoMediaAlt,


### PR DESCRIPTION
Minor feature parity with TD, brings over the Stay Open from checkbox from TD's composer into the Interface settings. Will close the composer alongside the pane reset procedure

<img width="324" height="329" alt="image" src="https://github.com/user-attachments/assets/94991327-2572-459c-a08a-4844a347f648" />

<img width="672" height="563" alt="image" src="https://github.com/user-attachments/assets/fb77b2d1-217e-4b97-a1d1-aecc75046ef2" />
