### PR TITLE
fix: import string for moderation filters id

### DIFF
--- a/app/desktop/lib/settings/backup.ts
+++ b/app/desktop/lib/settings/backup.ts
@@ -200,7 +200,7 @@ const modService = v.object({
 type ModService = v.Infer<typeof modService>;
 
 const wordFilter = v.object({
-	id: tidString,
+	id: v.string(),
 	name: v.string(),
 	pref: keywordFilterPref,
 


### PR DESCRIPTION
These appear to be stringed unix timestamps
https://github.com/mary-ext/skeetdeck/blob/trunk/app/desktop/components/settings/settings-views/keyword-filters/KeywordFilterFormView.tsx#L86
Resolves an `N: custom_error at .moderation.keywords.0.id (expected tid)` error on import